### PR TITLE
Throw error for unknown hiscores CSV format

### DIFF
--- a/__tests__/hiscores.test.ts
+++ b/__tests__/hiscores.test.ts
@@ -11,7 +11,8 @@ import {
   getPlayerTableURL,
   getSkillPageURL,
   getStatsURL,
-  BOSSES
+  BOSSES,
+  INVALID_FORMAT_ERROR
 } from '../src/index';
 
 const B0ATY_NAME = 'B0ATY';
@@ -230,6 +231,16 @@ test('Parse CSV to json', () => {
   };
 
   expect(parseStats(csv)).toStrictEqual(expectedOutput);
+});
+
+test('Parse CSV with unknown activity', () => {
+  const statsWithUnknownActivity = lynxTitanStats + `
+    -1,-1`;
+  expect(() => parseStats(statsWithUnknownActivity)).toThrow(INVALID_FORMAT_ERROR);
+});
+
+test('Parse invalid CSV', () => {
+  expect(() => parseStats('invalid')).toThrow(INVALID_FORMAT_ERROR);
 });
 
 describe('Get name format', () => {

--- a/src/hiscores.ts
+++ b/src/hiscores.ts
@@ -27,7 +27,8 @@ import {
   rsnFromElement,
   getActivityPageURL,
   httpGet,
-  BOSSES
+  BOSSES,
+  INVALID_FORMAT_ERROR
 } from './utils';
 
 /**
@@ -73,6 +74,10 @@ export function parseStats(csv: string): Stats {
     .split('\n')
     .filter((entry) => !!entry)
     .map((stat) => stat.split(','));
+
+  if (splitCSV.length !== SKILLS.length + BH_MODES.length + CLUES.length + BOSSES.length + 3) {
+    throw Error(INVALID_FORMAT_ERROR);
+  }
 
   const skillObjects: Skill[] = splitCSV
     .filter((stat) => stat.length === 3)

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -245,3 +245,5 @@ export const FORMATTED_BH_NAMES: FormattedBHNames = {
 export const FORMATTED_LMS = 'Last Man Standing';
 export const FORMATTED_SOUL_WARS = 'Soul Wars Zeal';
 export const FORMATTED_LEAGUE_POINTS = 'League Points';
+
+export const INVALID_FORMAT_ERROR = 'Invalid hiscores format';


### PR DESCRIPTION
I've implemented a simple check which throws if the CSV data obtained from OSRS hiscores is in an unknown format. This state may be caused e.g. by introduction of new hiscores activity or boss (such as the upcoming Nex or Raids 3).